### PR TITLE
Simplify x86 conditionals

### DIFF
--- a/fcd.xcodeproj/project.pbxproj
+++ b/fcd.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		DC01EF701B7BE9080077A356 /* clone.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC01EF6E1B7BE9080077A356 /* clone.cpp */; };
 		DC13DAA91B28C19D008115A7 /* pass_argrec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC13DAA81B28C19D008115A7 /* pass_argrec.cpp */; };
 		DC1517221B190096009DE513 /* symbolic_expr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC1517211B190096009DE513 /* symbolic_expr.cpp */; };
-		DC22FADD1BAC4E3D00050502 /* pass_signext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC22FADC1BAC4E3D00050502 /* pass_signext.cpp */; settings = {ASSET_TAGS = (); }; };
+		DC22FADD1BAC4E3D00050502 /* pass_signext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC22FADC1BAC4E3D00050502 /* pass_signext.cpp */; };
 		DC3A28E61AF4794D00FC9913 /* pass_reguse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC3A28E51AF4794D00FC9913 /* pass_reguse.cpp */; };
 		DC3A28E91AF7C5D400FC9913 /* x86_register_map.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC3A28E71AF7C5D400FC9913 /* x86_register_map.cpp */; };
 		DC3C5BAC1B5D409600D0B314 /* function.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC3C5BAA1B5D409600D0B314 /* function.cpp */; };
@@ -41,16 +41,17 @@
 		DC6D623D1AE1EE05009DDF2F /* libncurses.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = DC6D623C1AE1EE05009DDF2F /* libncurses.dylib */; };
 		DC6D623F1AE1F55A009DDF2F /* libcapstone.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DC6D623E1AE1F55A009DDF2F /* libcapstone.a */; };
 		DC6D62411AE1F591009DDF2F /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC6D62401AE1F591009DDF2F /* main.cpp */; };
+		DC778C7B1BDADF1F00C5A4FD /* pass_conditions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC778C7A1BDADF1F00C5A4FD /* pass_conditions.cpp */; };
 		DC7E04F11B9B299E003C8D10 /* MemorySSA.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC7E04F01B9B299E003C8D10 /* MemorySSA.cpp */; settings = {COMPILER_FLAGS = "-Wno-shorten-64-to-32"; }; };
-		DC95C7B41BB30F96005289E5 /* pass_ipa_reguse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC95C7B31BB30F96005289E5 /* pass_ipa_reguse.cpp */; settings = {ASSET_TAGS = (); }; };
-		DC95C7B61BB378DD005289E5 /* pass_lib_reguse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC95C7B51BB378DD005289E5 /* pass_lib_reguse.cpp */; settings = {ASSET_TAGS = (); }; };
-		DC95C7B91BB444CD005289E5 /* errors.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC95C7B71BB444CD005289E5 /* errors.cpp */; settings = {ASSET_TAGS = (); }; };
-		DC95C7BB1BB4B2E1005289E5 /* pass_interactive_reguse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC95C7BA1BB4B2E1005289E5 /* pass_interactive_reguse.cpp */; settings = {ASSET_TAGS = (); }; };
+		DC95C7B41BB30F96005289E5 /* pass_ipa_reguse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC95C7B31BB30F96005289E5 /* pass_ipa_reguse.cpp */; };
+		DC95C7B61BB378DD005289E5 /* pass_lib_reguse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC95C7B51BB378DD005289E5 /* pass_lib_reguse.cpp */; };
+		DC95C7B91BB444CD005289E5 /* errors.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC95C7B71BB444CD005289E5 /* errors.cpp */; };
+		DC95C7BB1BB4B2E1005289E5 /* pass_interactive_reguse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC95C7BA1BB4B2E1005289E5 /* pass_interactive_reguse.cpp */; };
 		DC95C7BD1BB4E006005289E5 /* Python.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC95C7BC1BB4E006005289E5 /* Python.framework */; };
-		DC95C7C01BB4E021005289E5 /* pass_python.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC95C7BE1BB4E021005289E5 /* pass_python.cpp */; settings = {ASSET_TAGS = (); }; };
-		DC95C7C31BB61F63005289E5 /* bindings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC95C7C21BB61F63005289E5 /* bindings.cpp */; settings = {ASSET_TAGS = (); }; };
-		DC9865811BB06BE8005AA3D9 /* command_line.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC98657F1BB06BE8005AA3D9 /* command_line.cpp */; settings = {ASSET_TAGS = (); }; };
-		DC9865841BB08A71005AA3D9 /* executable_errors.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC9865821BB08A71005AA3D9 /* executable_errors.cpp */; settings = {ASSET_TAGS = (); }; };
+		DC95C7C01BB4E021005289E5 /* pass_python.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC95C7BE1BB4E021005289E5 /* pass_python.cpp */; };
+		DC95C7C31BB61F63005289E5 /* bindings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC95C7C21BB61F63005289E5 /* bindings.cpp */; };
+		DC9865811BB06BE8005AA3D9 /* command_line.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC98657F1BB06BE8005AA3D9 /* command_line.cpp */; };
+		DC9865841BB08A71005AA3D9 /* executable_errors.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC9865821BB08A71005AA3D9 /* executable_errors.cpp */; };
 		DCAFBF9F1AE5607300B8C4BC /* result_function.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DCAFBF9D1AE5607200B8C4BC /* result_function.cpp */; };
 		DCAFBFA51AE5B9EB00B8C4BC /* capstone_wrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DCAFBFA31AE5B9EB00B8C4BC /* capstone_wrapper.cpp */; };
 		DCAFBFA81AE5E39F00B8C4BC /* translation_context.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DCAFBFA61AE5E39F00B8C4BC /* translation_context.cpp */; };
@@ -66,7 +67,7 @@
 		DCCD51FB1AEC4FD600AAF640 /* capstone_wrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DCAFBFA31AE5B9EB00B8C4BC /* capstone_wrapper.cpp */; };
 		DCCD51FC1AEC4FF100AAF640 /* libcapstone.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DC6D623E1AE1F55A009DDF2F /* libcapstone.a */; };
 		DCCD51FF1AEDBAB700AAF640 /* x86_tests.S in Sources */ = {isa = PBXBuildFile; fileRef = DCCD51FD1AEDBAB700AAF640 /* x86_tests.S */; settings = {COMPILER_FLAGS = "-mllvm --x86-asm-syntax=intel"; }; };
-		DCD8B1831BAE1A3F00968A83 /* flat_binary.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DCD8B1811BAE1A3F00968A83 /* flat_binary.cpp */; settings = {ASSET_TAGS = (); }; };
+		DCD8B1831BAE1A3F00968A83 /* flat_binary.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DCD8B1811BAE1A3F00968A83 /* flat_binary.cpp */; };
 		DCD8BF3E1B2B6E6100E2EA3C /* pass_targetinfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DCD8BF3C1B2B6E6100E2EA3C /* pass_targetinfo.cpp */; };
 		DCE5F6511B46CA0B000906F5 /* grapher.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DCE5F64F1B46CA0B000906F5 /* grapher.cpp */; };
 		DCE5F6541B4733F5000906F5 /* nodes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DCE5F6521B4733F5000906F5 /* nodes.cpp */; };
@@ -145,6 +146,7 @@
 		DC6D623E1AE1F55A009DDF2F /* libcapstone.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libcapstone.a; path = "../../Library/Developer/Xcode/DerivedData/ReverseKit-cqoklmuymkathpgdrifqtelkxhrr/Build/Products/Debug/libcapstone.a"; sourceTree = "<group>"; };
 		DC6D62401AE1F591009DDF2F /* main.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = main.cpp; sourceTree = "<group>"; };
 		DC6D62421AE1F61E009DDF2F /* x86_defs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = x86_defs.h; sourceTree = "<group>"; };
+		DC778C7A1BDADF1F00C5A4FD /* pass_conditions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pass_conditions.cpp; sourceTree = "<group>"; };
 		DC7E04EF1B9B298C003C8D10 /* MemorySSA.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MemorySSA.h; sourceTree = "<group>"; };
 		DC7E04F01B9B299E003C8D10 /* MemorySSA.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MemorySSA.cpp; sourceTree = "<group>"; };
 		DC89D8551ACDB2A00001C92D /* x86_emulator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = x86_emulator.cpp; sourceTree = "<group>"; };
@@ -392,6 +394,7 @@
 				DC01EF6D1B7BE2EA0077A356 /* not_null.h */,
 				DC13DAA81B28C19D008115A7 /* pass_argrec.cpp */,
 				DCAFBFBC1AE6E3BD00B8C4BC /* pass_asaa.cpp */,
+				DC778C7A1BDADF1F00C5A4FD /* pass_conditions.cpp */,
 				DC95C7BA1BB4B2E1005289E5 /* pass_interactive_reguse.cpp */,
 				DC95C7B31BB30F96005289E5 /* pass_ipa_reguse.cpp */,
 				DCB25D771B2FAD37000E4416 /* pass_regptrpromotion.cpp */,
@@ -560,6 +563,7 @@
 				DC95C7B41BB30F96005289E5 /* pass_ipa_reguse.cpp in Sources */,
 				DC3A28E91AF7C5D400FC9913 /* x86_register_map.cpp in Sources */,
 				DCCA432B1B7991520012560E /* pass.cpp in Sources */,
+				DC778C7B1BDADF1F00C5A4FD /* pass_conditions.cpp in Sources */,
 				DC1517221B190096009DE513 /* symbolic_expr.cpp in Sources */,
 				DC01EF601B7BA13D0077A356 /* visitor.cpp in Sources */,
 				DCE5F6511B46CA0B000906F5 /* grapher.cpp in Sources */,

--- a/fcd/main.cpp
+++ b/fcd/main.cpp
@@ -335,6 +335,7 @@ namespace
 					// IPA can only work when complete disassembly is used
 					phaseTwo.add(createIpaRegisterUsePass());
 				}
+				phaseTwo.add(createConditionSimplificationPass());
 				phaseTwo.add(createGVNPass());
 				phaseTwo.add(createDeadStoreEliminationPass());
 				phaseTwo.add(createInstructionCombiningPass());

--- a/fcd/pass_conditions.cpp
+++ b/fcd/pass_conditions.cpp
@@ -1,0 +1,52 @@
+//
+// pass_conditions.cpp
+// Copyright (C) 2015 Félix Cloutier.
+// All Rights Reserved.
+//
+// This file is part of fcd.
+// 
+// fcd is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// fcd is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with fcd.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "passes.h"
+
+SILENCE_LLVM_WARNINGS_BEGIN()
+SILENCE_LLVM_WARNINGS_END()
+
+using namespace llvm;
+using namespace std;
+
+namespace
+{
+	struct ConditionSimplification : public FunctionPass
+	{
+		static char ID;
+		
+		ConditionSimplification() : FunctionPass(ID)
+		{
+		}
+		
+		virtual bool runOnFunction(Function& fn) override
+		{
+			return false;
+		}
+	};
+	
+	char ConditionSimplification::ID = 0;
+}
+
+FunctionPass* createConditionSimplificationPass()
+{
+	return new ConditionSimplification;
+}

--- a/fcd/pass_conditions.cpp
+++ b/fcd/pass_conditions.cpp
@@ -23,13 +23,83 @@
 
 SILENCE_LLVM_WARNINGS_BEGIN()
 #include <llvm/IR/IntrinsicInst.h>
+#include <llvm/IR/PatternMatch.h>
 SILENCE_LLVM_WARNINGS_END()
 
 using namespace llvm;
+using namespace llvm::PatternMatch;
 using namespace std;
 
 namespace
 {
+	Value* matchGetSignFlag(Value& value)
+	{
+		Value* from = &value;
+		while (auto asCast = dyn_cast<CastInst>(from))
+		{
+			from = asCast->getOperand(0);
+		}
+		
+		Value* operand = nullptr;
+		ConstantInt* shiftAmount = nullptr;
+		if (match(from, m_LShr(m_Value(operand), m_ConstantInt(shiftAmount))))
+		if (operand->getType()->getIntegerBitWidth() == shiftAmount->getLimitedValue() + 1)
+		{
+			return operand;
+		}
+		return nullptr;
+	}
+	
+	bool isXorSub(BinaryOperator& xorInst, Value*& left, Value*& right)
+	{
+		Value* xorOp = nullptr;
+		auto sub = m_Sub(m_Value(left), m_Value(right));
+		if (match(&xorInst, m_Xor(m_Value(xorOp), sub)) && xorOp == left)
+		{
+			return true;
+		}
+		return match(&xorInst, m_Xor(sub, m_Value(xorOp))) && xorOp == left;
+	}
+	
+	bool isOverflowTest(Value& value, Value*& a, Value*& b)
+	{
+		// %0 = sub %a, %b
+		// %1 = xor %a, %b
+		// %2 = xor %a, %0
+		// %3 = and %1, %2
+		
+		auto xorOp = Instruction::Xor;
+		BinaryOperator* left = nullptr;
+		BinaryOperator* right = nullptr;
+		if (match(&value, m_And(m_BinOp(left), m_BinOp(right))) && left->getOpcode() == xorOp && right->getOpcode() == xorOp)
+		{
+			Value* subLeft = nullptr;
+			Value* subRight = nullptr;
+			BinaryOperator* xorValues = nullptr;
+			if (isXorSub(*left, subLeft, subRight))
+			{
+				xorValues = right;
+			}
+			else if (isXorSub(*right, subLeft, subRight))
+			{
+				xorValues = left;
+			}
+			
+			if (xorValues != nullptr)
+			{
+				auto op0 = xorValues->getOperand(0);
+				auto op1 = xorValues->getOperand(1);
+				if ((op0 == subLeft && op1 == subRight) || (op0 == subRight && op1 == subLeft))
+				{
+					a = subLeft;
+					b = subRight;
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+	
 	struct ConditionSimplification : public FunctionPass
 	{
 		static char ID;
@@ -54,11 +124,45 @@ namespace
 			// Attempt to remove uses of usub_with_overflow by replacig its bool element with icmp ult.
 			for (auto& inst : bb)
 			{
-				if (inst.getOpcode() == Instruction::Call)
-				if (auto intrin = dyn_cast<IntrinsicInst>(&inst))
-				if (intrin->getIntrinsicID() == Intrinsic::usub_with_overflow)
+				auto opcode = inst.getOpcode();
+				if (opcode == Instruction::Call)
 				{
-					result |= replaceUsubWithOverflow(*intrin);
+					if (auto intrin = dyn_cast<IntrinsicInst>(&inst))
+					if (intrin->getIntrinsicID() == Intrinsic::usub_with_overflow)
+					{
+						result |= replaceUsubWithOverflow(*intrin);
+					}
+				}
+				else if (opcode == Instruction::ICmp)
+				{
+					auto& icmp = cast<ICmpInst>(inst);
+					auto pred = icmp.getPredicate();
+					if (pred == ICmpInst::ICMP_EQ || pred == ICmpInst::ICMP_NE)
+					{
+						if (auto left = matchGetSignFlag(*icmp.getOperand(0)))
+						if (auto right = matchGetSignFlag(*icmp.getOperand(1)))
+						{
+							Value* compareLeft = nullptr;
+							Value* compareRight = nullptr;
+							Value* testMatch = nullptr;
+							if (isOverflowTest(*left, compareLeft, compareRight))
+							{
+								testMatch = right;
+							}
+							else if (isOverflowTest(*right, compareLeft, compareRight))
+							{
+								testMatch = left;
+							}
+							
+							if (testMatch != nullptr && match(testMatch, m_Sub(m_Value(compareLeft), m_Value(compareRight))))
+							{
+								auto newPred = pred == ICmpInst::ICMP_EQ ? ICmpInst::ICMP_SGE : ICmpInst::ICMP_SLE;
+								auto newComp = ICmpInst::Create(Instruction::ICmp, newPred, compareLeft, compareRight, "", &icmp);
+								icmp.replaceAllUsesWith(newComp);
+								result = true;
+							}
+						}
+					}
 				}
 			}
 			return result;

--- a/fcd/passes.h
+++ b/fcd/passes.h
@@ -46,6 +46,7 @@ llvm::ModulePass*		createLibraryRegisterUsePass();
 llvm::FunctionPass*		createRegisterPointerPromotionPass();
 llvm::FunctionPass*		createSESELoopPass();
 llvm::FunctionPass*		createSignExtPass();
+llvm::FunctionPass*		createConditionSimplificationPass();
 TargetInfo*				createTargetInfoPass();
 
 namespace llvm


### PR DESCRIPTION
x86 conditionals use boolean operations on CPU flags with patterns that LLVM doesn't recognize. This causes some rather obtuse conditions to appear in the decompiled code. This new pass optimizes the patterns into icmp instructions, which make a lot more sense; it also ensures that the `usub_with_overflow` intrinsic doesn't make it to the AST generation pass, enhancing compatibility.