### PR TITLE
Upgrade to LLVM 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,30 +4,27 @@ sudo: true
 
 env:
   global:
-  - LLVM_VERSION=3.9.0
   - TRAVIS_ENCRYPTION_LABEL="d0f036b99c7e"
 
 matrix:
   include:
   - os: linux
-    env: LLVM_ARCH="x86_64-linux-gnu-debian8"
   - os: osx
-    env: LLVM_ARCH="x86_64-apple-darwin"
 
 addons:
   apt:
     sources:
-    - llvm-toolchain-trusty-3.9
+    - llvm-toolchain-trusty-4.0
     - ubuntu-toolchain-r-test
     packages:
-    - clang-3.9
-    - clang-3.9-dev
+    - clang-4.0
+    - clang-4.0-dev
     - cmake
     - cmake-data
     - libz-dev
     - libedit-dev
-    - llvm-3.9
-    - llvm-3.9-dev
+    - llvm-4.0
+    - llvm-4.0-dev
     - libstdc++-6-dev
     - python-dev
 
@@ -47,17 +44,16 @@ install:
     brew update;
     brew install capstone;
     mkdir -p "llvm-${LLVM_VERSION}";
-    curl -s "http://releases.llvm.org/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-${LLVM_ARCH}.tar.xz" -o llvm.tar.xz;
-    tar -xf llvm.tar.xz --strip-components=1 -C "llvm-${LLVM_VERSION}";
+    curl -s "http://llvm.org/pre-releases/4.0.0/rc2/clang+llvm-4.0.0-rc2-x86_64-apple-darwin.tar.xz" -o llvm.tar.xz;
+    tar -xf llvm.tar.xz --strip-components=1 -C llvm;
   fi;
 
 script:
 - 
   if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
     rm -rf build && mkdir build && pushd build;
-    export LLVM_DIR="/usr/lib/llvm-3.9/lib/cmake/llvm/";
-    export Clang_DIR="/usr/share/llvm-3.9/cmake/";
-    export CC="clang-3.9" CXX="clang++-3.9";
+    export LLVM_DIR="/usr/lib/llvm-4.0/lib/cmake/llvm/";
+    export CC="clang-4.0" CXX="clang++-4.0";
     cmake ..;
     if make -j3; then
       export FCD="build/fcd";
@@ -66,7 +62,7 @@ script:
     fi;
     popd;
   else
-    if xcodebuild -target fcd -configuration Release CAPSTONE_DIR="/usr/local/Cellar/capstone/3.0.4" LLVM_BUILD_DIR="llvm-${LLVM_VERSION}"; then
+    if xcodebuild -target fcd -configuration Release CAPSTONE_DIR="/usr/local/Cellar/capstone/3.0.4" LLVM_BUILD_DIR="llvm"; then
       export FCD="build/Release/fcd";
     else
       exit 1;

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
   else
     brew update;
     brew install capstone;
-    mkdir -p "llvm-${LLVM_VERSION}";
+    mkdir -p "llvm";
     curl -s "http://llvm.org/pre-releases/4.0.0/rc2/clang+llvm-4.0.0-rc2-x86_64-apple-darwin.tar.xz" -o llvm.tar.xz;
     tar -xf llvm.tar.xz --strip-components=1 -C llvm;
   fi;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 set(CMAKE_BUILD_TYPE Debug)
 set(CMAKE_CXX_STANDARD 14)
 
-find_package(LLVM 3.9 REQUIRED CONFIG)
+find_package(LLVM 4.0 REQUIRED CONFIG)
 find_package(PythonLibs 2.7 REQUIRED)
 
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION} @ ${LLVM_DIR}")
@@ -76,7 +76,8 @@ execute_process(COMMAND ldd "${LLVM_LIBRARY_DIR}/libclang.so" COMMAND grep -q li
 
 if (${linked_to_libllvm} EQUAL 0)
 	message(STATUS "Link to LLVM shared library.")
-	set(llvm_libs -lLLVM-3.9)
+	# XXX: This shouldn't reference the specific LLVM version.
+	set(llvm_libs -lLLVM-4.0)
 else()
 	message(STATUS "Link to LLVM static libraries.")
 	llvm_map_components_to_libnames(llvm_libs analysis asmparser bitreader codegen core coverage instcombine instrumentation ipo irreader linker mc mcparser object option passes profiledata scalaropts support target transformutils vectorize)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,16 +8,17 @@ Please report build issues in the issue tracker.
 
 ## Building on Mac OS X
 
-To build it with Xcode, you need to change the `CAPSTONE_DIR`, `LLVM_BIN_DIR`, `LLVM_BUILD_DIR`, `LLVM_SRC_DIR`, `CLANG_SRC_DIR` and `CLANG_BIN_DIR` user-defined variables to match the correct locations on your system.
+To build it with Xcode, you need to change the `CAPSTONE_DIR`, `LLVM_BIN_DIR`, `LLVM_BUILD_DIR`, `LLVM_SRC_DIR`, `CLANG_SRC_DIR`, `CLANG_BIN_DIR` and `CLANG_BUILD_DIR` user-defined variables to match the correct locations on your system.
 
-By default, every `LLVM_*_DIR` and `CLANG_*_DIR` variables point to the same directory, and just reference `LLVM_BUILD_DIR` (such that changing that one only changes all the others). If you downloaded a pre-built LLVM distribution, you can use the decompressed root path directly.
+By default, every `LLVM_*_DIR` and `CLANG_*_DIR` variables just reference `LLVM_BUILD_DIR` (such that changing that one only changes all the others). This is adequate when you download an official LLVM build from the LLVM download page, and the path just needs to be the root of the decompressed archive. If you do this, you don't have to care about any other variable.
 
 * `CAPSTONE_DIR`: this should point to a directory in which can be found an "include/capstone/capstone.h" file. If you've installed capstone with Homebrew, this will be `/usr/local/Cellar/capstone/3.0.4`. Fcd is tested with Capstone 3.0.4.
 * `LLVM_BIN_DIR`: this should point to a directory that contains a `/lib` directory with all the LLVM .a archives, and a `/bin` directory with the `clang` and `clang++` binaries. It is very important that *this* Clang version is linked against the same LLVM build that fcd does.
-* `LLVM_BUILD_DIR`: this should point to a directory that contains a `/include` directory where LLVM outputs its build-specific headers.
-* `LLVM_SRC_DIR`: this should point to a directory that contains a `/include` directory where the main LLVM headers reside. If you have a pre-built version of LLVM, this is the same as `LLVM_BUILD_DIR`.
-* `CLANG_SRC_DIR` is the directory that contains a `/include` directory where the Clang includes reside. If you have a pre-built version of LLVM taken from the LLVM website, this is the same as `LLVM_SRC_DIR`.
-* `CLANG_BIN_DIR` is the directory that contains a `/lib` director with all the Clang .a files. This is also the same as `LLVM_BIN_DIR` if you grab a build from the LLVM website.
+* `LLVM_BUILD_DIR`: this should point to a directory that contains a `/include` directory where LLVM outputs its build-specific headers. If you locally built LLVM, this is the same as `LLVM_BIN_DIR`.
+* `LLVM_SRC_DIR`: this should point to a directory that contains a `/include` directory where the main LLVM headers reside. If you have a locally built LLVM, this is the source root.
+* `CLANG_SRC_DIR` is the directory that contains a `/include` directory where the Clang includes reside. If you have a locally built Clang, this is the Clang source root, which you typically put in `$LLVM_SRC_DIR/tools/clang`.
+* `CLANG_BIN_DIR` is the directory that contains a `/lib` directory with all the Clang .a files. If you have a locally built Clang, this is the same as `LLVM_BIN_DIR`.
+* `CLANG_BUILD_DIR` is the directory that contains a `/include` directory where the build outputs build-specific headers. On a locally built Clang, this is typically `$LLVM_BUILD_DIR/tools/clang`.
 
 With all that, the traditional Command+R should allow fcd to build and run.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Building fcd
 
-Fcd compiles against the LLVM 3.9.0 release. It has been tested (to the small extent to which fcd is tested) on Mac OS X. Automated test results are available on the [fcd-tests repository][2].
+Fcd compiles against the LLVM 4.0 release. It has been tested on macOS, and is at least known to build on Ubuntu. Automated test results are available on the [fcd-tests repository][2].
 
 **Even LLVM dot releases can break API compatibility. For a smooth build experience, make sure that you have this exact version of LLVM.**
 
@@ -8,7 +8,9 @@ Please report build issues in the issue tracker.
 
 ## Building on Mac OS X
 
-Fcd is currently built with Xcode 8. The project defines a number of build variables that you may need to modify according to your installation.
+To build it with Xcode, you need to change the `CAPSTONE_DIR`, `LLVM_BIN_DIR`, `LLVM_BUILD_DIR`, `LLVM_SRC_DIR`, `CLANG_SRC_DIR` and `CLANG_BIN_DIR` user-defined variables to match the correct locations on your system.
+
+By default, every `LLVM_*_DIR` and `CLANG_*_DIR` variables point to the same directory, and just reference `LLVM_BUILD_DIR` (such that changing that one only changes all the others). If you downloaded a pre-built LLVM distribution, you can use the decompressed root path directly.
 
 * `CAPSTONE_DIR`: this should point to a directory in which can be found an "include/capstone/capstone.h" file. If you've installed capstone with Homebrew, this will be `/usr/local/Cellar/capstone/3.0.4`. Fcd is tested with Capstone 3.0.4.
 * `LLVM_BIN_DIR`: this should point to a directory that contains a `/lib` directory with all the LLVM .a archives, and a `/bin` directory with the `clang` and `clang++` binaries. It is very important that *this* Clang version is linked against the same LLVM build that fcd does.
@@ -17,13 +19,11 @@ Fcd is currently built with Xcode 8. The project defines a number of build varia
 * `CLANG_SRC_DIR` is the directory that contains a `/include` directory where the Clang includes reside. If you have a pre-built version of LLVM taken from the LLVM website, this is the same as `LLVM_SRC_DIR`.
 * `CLANG_BIN_DIR` is the directory that contains a `/lib` director with all the Clang .a files. This is also the same as `LLVM_BIN_DIR` if you grab a build from the LLVM website.
 
-By default, all of the `LLVM_*_DIR` variables are set to `LLVM_BUILD_DIR`. If you have downloaded a binary release of LLVM from the LLVM website, you only need to set `LLVM_BUILD_DIR` to the uncompressed root of the release.
-
 With all that, the traditional Command+R should allow fcd to build and run.
 
 Fcd can also be built with a mere developer command-line tools installation using `xcodebuild`. To build fcd using `xcodebuild`, you would move to the directory that contains `fcd.xcodeproj` and then run something like:
 
-    $ xcodebuild -target fcd -configuration Release CAPSTONE_DIR="/usr/local/Cellar/capstone/3.0.4" LLVM_BUILD_DIR="../llvm-3.9"
+    $ xcodebuild -target fcd -configuration Release CAPSTONE_DIR="/usr/local/Cellar/capstone/3.0.4" LLVM_BUILD_DIR="../llvm-4.0"
 
 ## Building on Linux
 
@@ -31,8 +31,8 @@ Fcd builds on Linux using the provided top-level CMakeLists.txt file. It is know
 
 The following packages need to be installed:
 
-* clang-3.9
-* clang-3.9-dev
+* clang-4.0
+* clang-4.0-dev
 * cmake (version 3.2)
 * cmake-data
 * libz-dev (this can also be zlib1g-dev or lib32z1-dev)
@@ -40,8 +40,8 @@ The following packages need to be installed:
 * libcapstone-dev
 * libedit-dev
 * libstdc++-dev (version 6 or better)
-* llvm-3.9
-* llvm-3.9-dev
+* llvm-4.0
+* llvm-4.0-dev
 * python-dev (Python 2.7)
 
 They should be available through your package manager. LLVM specifically is also available on the [LLVM apt repository][4].

--- a/fcd.xcodeproj/project.pbxproj
+++ b/fcd.xcodeproj/project.pbxproj
@@ -779,7 +779,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
-			shellScript = "BINDINGS_SCRIPT=\"$SRCROOT/fcd/python/bindings.py\"\nCLANG=\"$LLVM_BIN_DIR/bin/clang\"\nDEFINES=$(sed 's/[^ ][^ ]*/-D&/g' <(echo $GCC_PREPROCESSOR_DEFINITIONS))\nINCLUDES=\"-isysroot $SDKROOT -I$LLVM_SRC_DIR/include\"\nINPUT_FILE=\"$LLVM_SRC_DIR/include/llvm-c/Core.h\"\n\n$CLANG -E -o - $DEFINES $INCLUDES $INPUT_FILE_PATH $INPUT_FILE | python $BINDINGS_SCRIPT > $DERIVED_FILE_DIR/bindings.cpp\n";
+			shellScript = "BINDINGS_SCRIPT=\"$SRCROOT/fcd/python/bindings.py\"\nCLANG=\"$LLVM_BIN_DIR/bin/clang\"\nDEFINES=$(sed 's/[^ ][^ ]*/-D&/g' <(echo $GCC_PREPROCESSOR_DEFINITIONS))\nINCLUDES=\"-isysroot $SDKROOT -I$LLVM_SRC_DIR/include -I$LLVM_BUILD_DIR/include\"\nINPUT_FILE=\"$LLVM_SRC_DIR/include/llvm-c/Core.h\"\n\n$CLANG -E -o - $DEFINES $INCLUDES $INPUT_FILE_PATH $INPUT_FILE | python $BINDINGS_SCRIPT > $DERIVED_FILE_DIR/bindings.cpp\n";
 			showEnvVarsInLog = 0;
 		};
 		DCEC45731D7B776000A8F1DD /* Get system include paths */ = {
@@ -890,6 +890,7 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CAPSTONE_DIR = /usr/local/Cellar/capstone/3.0.4;
 				CLANG_BIN_DIR = "$(LLVM_BIN_DIR)";
+				CLANG_BUILD_DIR = "$(LLVM_BUILD_DIR)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++14";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -941,6 +942,7 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CAPSTONE_DIR = /usr/local/Cellar/capstone/3.0.4;
 				CLANG_BIN_DIR = "$(LLVM_BIN_DIR)";
+				CLANG_BUILD_DIR = "$(LLVM_BUILD_DIR)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++14";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -999,6 +1001,7 @@
 					"$(LLVM_BUILD_DIR)/include",
 					"$(CAPSTONE_DIR)/include",
 					"$(CLANG_SRC_DIR)/include",
+					"$(CLANG_BUILD_DIR)/include",
 				);
 				LD_RUNPATH_SEARCH_PATHS = "$(LLVM_BIN_DIR)/lib";
 				LIBRARY_SEARCH_PATHS = (
@@ -1035,6 +1038,7 @@
 					"$(LLVM_BUILD_DIR)/include",
 					"$(CAPSTONE_DIR)/include",
 					"$(CLANG_SRC_DIR)/include",
+					"$(CLANG_BUILD_DIR)/include",
 				);
 				LD_RUNPATH_SEARCH_PATHS = "$(LLVM_BIN_DIR)/lib";
 				LIBRARY_SEARCH_PATHS = (

--- a/fcd.xcodeproj/project.pbxproj
+++ b/fcd.xcodeproj/project.pbxproj
@@ -60,10 +60,10 @@
 		DC83CA971CE8F887008E373C /* libLLVMVectorize.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DC83CA841CE8F887008E373C /* libLLVMVectorize.a */; };
 		DC83CA991CE8F977008E373C /* libLLVMAsmParser.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DC83CA981CE8F977008E373C /* libLLVMAsmParser.a */; };
 		DC83CA9B1CE8F9B5008E373C /* libLLVMObject.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DC83CA9A1CE8F9B5008E373C /* libLLVMObject.a */; };
-		DC878FB11E38639800D78A1F /* libLLVMDemangle.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DC878FB01E38639800D78A1F /* libLLVMDemangle.a */; };
 		DC84358C1CA8498100DE93C6 /* print_item.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC84358A1CA8498100DE93C6 /* print_item.cpp */; };
 		DC84358F1CA8E59600DE93C6 /* print.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC84358D1CA8E59600DE93C6 /* print.cpp */; };
 		DC8435921CA8E96B00DE93C6 /* type_printer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC8435901CA8E96B00DE93C6 /* type_printer.cpp */; };
+		DC878FB11E38639800D78A1F /* libLLVMDemangle.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DC878FB01E38639800D78A1F /* libLLVMDemangle.a */; };
 		DC93E3741E5F4DC90094A0CB /* pass_congruence.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC93E3731E5F4DC90094A0CB /* pass_congruence.cpp */; };
 		DC95C7B91BB444CD005289E5 /* errors.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC95C7B71BB444CD005289E5 /* errors.cpp */; };
 		DC95C7BD1BB4E006005289E5 /* Python.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC95C7BC1BB4E006005289E5 /* Python.framework */; };
@@ -926,7 +926,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				LLVM_BIN_DIR = "$(LLVM_BUILD_DIR)";
-				LLVM_BUILD_DIR = "$(HOME)/Projets/clang+llvm-4.0.0-rc2-x86_64-apple-darwin";
+				LLVM_BUILD_DIR = "$(HOME)/Projets/clang+llvm-4.0.0-x86_64-apple-darwin";
 				LLVM_SRC_DIR = "$(LLVM_BUILD_DIR)";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -974,7 +974,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				LLVM_BIN_DIR = "$(LLVM_BUILD_DIR)";
-				LLVM_BUILD_DIR = "$(HOME)/Projets/clang+llvm-4.0.0-rc2-x86_64-apple-darwin";
+				LLVM_BUILD_DIR = "$(HOME)/Projets/clang+llvm-4.0.0-x86_64-apple-darwin";
 				LLVM_SRC_DIR = "$(LLVM_BUILD_DIR)";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;

--- a/fcd.xcodeproj/project.pbxproj
+++ b/fcd.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		DC83CA971CE8F887008E373C /* libLLVMVectorize.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DC83CA841CE8F887008E373C /* libLLVMVectorize.a */; };
 		DC83CA991CE8F977008E373C /* libLLVMAsmParser.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DC83CA981CE8F977008E373C /* libLLVMAsmParser.a */; };
 		DC83CA9B1CE8F9B5008E373C /* libLLVMObject.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DC83CA9A1CE8F9B5008E373C /* libLLVMObject.a */; };
+		DC878FB11E38639800D78A1F /* libLLVMDemangle.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DC878FB01E38639800D78A1F /* libLLVMDemangle.a */; };
 		DC84358C1CA8498100DE93C6 /* print_item.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC84358A1CA8498100DE93C6 /* print_item.cpp */; };
 		DC84358F1CA8E59600DE93C6 /* print.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC84358D1CA8E59600DE93C6 /* print.cpp */; };
 		DC8435921CA8E96B00DE93C6 /* type_printer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC8435901CA8E96B00DE93C6 /* type_printer.cpp */; };
@@ -225,6 +226,7 @@
 		DC8435901CA8E96B00DE93C6 /* type_printer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = type_printer.cpp; sourceTree = "<group>"; };
 		DC8435911CA8E96B00DE93C6 /* type_printer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = type_printer.h; sourceTree = "<group>"; };
 		DC878FAE1E383B2F00D78A1F /* CodeGenTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CodeGenTypes.h; sourceTree = "<group>"; };
+		DC878FB01E38639800D78A1F /* libLLVMDemangle.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMDemangle.a; path = "$(LLVM_BIN_DIR)/lib/libLLVMDemangle.a"; sourceTree = "<group>"; };
 		DC89D8551ACDB2A00001C92D /* x86.emulator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = x86.emulator.cpp; path = ../cpu/x86.emulator.cpp; sourceTree = "<group>"; };
 		DC89D8561ACDB2A00001C92D /* x86.emulator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = x86.emulator.h; path = ../cpu/x86.emulator.h; sourceTree = "<group>"; };
 		DC93E3731E5F4DC90094A0CB /* pass_congruence.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pass_congruence.cpp; sourceTree = "<group>"; };
@@ -340,6 +342,7 @@
 				DC83CA881CE8F887008E373C /* libLLVMCodeGen.a in Frameworks */,
 				DC83CA891CE8F887008E373C /* libLLVMCore.a in Frameworks */,
 				DCCEC78F1D79D158004D341E /* libLLVMCoverage.a in Frameworks */,
+				DC878FB11E38639800D78A1F /* libLLVMDemangle.a in Frameworks */,
 				DC83CA8A1CE8F887008E373C /* libLLVMInstCombine.a in Frameworks */,
 				DC83CA8B1CE8F887008E373C /* libLLVMInstrumentation.a in Frameworks */,
 				DC83CA8C1CE8F887008E373C /* libLLVMipo.a in Frameworks */,
@@ -490,6 +493,7 @@
 				DC83CA751CE8F887008E373C /* libLLVMCodeGen.a */,
 				DC83CA761CE8F887008E373C /* libLLVMCore.a */,
 				DCCEC78E1D79D158004D341E /* libLLVMCoverage.a */,
+				DC878FB01E38639800D78A1F /* libLLVMDemangle.a */,
 				DC83CA771CE8F887008E373C /* libLLVMInstCombine.a */,
 				DC83CA781CE8F887008E373C /* libLLVMInstrumentation.a */,
 				DC83CA791CE8F887008E373C /* libLLVMipo.a */,
@@ -913,7 +917,10 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "FCD_DEBUG=1";
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_MISSING_NEWLINE = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = YES;
+				GCC_WARN_NON_VIRTUAL_DESTRUCTOR = NO;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
@@ -921,14 +928,8 @@
 				LLVM_BIN_DIR = "$(LLVM_BUILD_DIR)";
 				LLVM_BUILD_DIR = "$(HOME)/Projets/clang+llvm-4.0.0-rc1-x86_64-apple-darwin";
 				LLVM_SRC_DIR = "$(LLVM_BUILD_DIR)";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"--system-header-prefix=llvm/",
-					"--system-header-prefix=clang-c/",
-					"--system-header-prefix=clang/",
-				);
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -964,7 +965,10 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = "";
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_MISSING_NEWLINE = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = YES;
+				GCC_WARN_NON_VIRTUAL_DESTRUCTOR = NO;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
@@ -972,13 +976,7 @@
 				LLVM_BIN_DIR = "$(LLVM_BUILD_DIR)";
 				LLVM_BUILD_DIR = "$(HOME)/Projets/clang+llvm-4.0.0-rc1-x86_64-apple-darwin";
 				LLVM_SRC_DIR = "$(LLVM_BUILD_DIR)";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_CFLAGS = (
-					"--system-header-prefix=llvm/",
-					"--system-header-prefix=clang-c/",
-					"--system-header-prefix=clang/",
-				);
 				SDKROOT = macosx;
 			};
 			name = Release;
@@ -986,7 +984,6 @@
 		DCAFCA341AD6F2110095E89E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++14";
 				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = NO;
 				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = NO;
 				GCC_ENABLE_CPP_RTTI = NO;
@@ -995,9 +992,6 @@
 					__STDC_LIMIT_MACROS,
 					"$(inherited)",
 				);
-				GCC_WARN_ABOUT_MISSING_NEWLINE = YES;
-				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = YES;
-				GCC_WARN_NON_VIRTUAL_DESTRUCTOR = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
@@ -1013,7 +1007,11 @@
 					"$(LLVM_BIN_DIR)/lib",
 					"$(CAPSTONE_DIR)/lib",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				OTHER_CFLAGS = (
+					"--system-header-prefix=llvm/",
+					"--system-header-prefix=clang-c/",
+					"--system-header-prefix=clang/",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				USER_HEADER_SEARCH_PATHS = "";
 			};
@@ -1026,13 +1024,10 @@
 				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = NO;
 				GCC_ENABLE_CPP_RTTI = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
 					__STDC_CONSTANT_MACROS,
 					__STDC_LIMIT_MACROS,
-					"$(inherited)",
 				);
-				GCC_WARN_ABOUT_MISSING_NEWLINE = YES;
-				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = YES;
-				GCC_WARN_NON_VIRTUAL_DESTRUCTOR = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
@@ -1048,6 +1043,11 @@
 					"$(LLVM_BIN_DIR)/lib",
 					"$(CAPSTONE_DIR)/lib",
 				);
+				OTHER_CFLAGS = (
+					"--system-header-prefix=llvm/",
+					"--system-header-prefix=clang-c/",
+					"--system-header-prefix=clang/",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				USER_HEADER_SEARCH_PATHS = "";
 			};
@@ -1057,12 +1057,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
 					"$(inherited)",
+					"DEBUG=1",
 					__STDC_CONSTANT_MACROS,
 					__STDC_LIMIT_MACROS,
 				);
-				GCC_VERSION = "";
 				HEADER_SEARCH_PATHS = (
 					"$(LLVM_SRC_DIR)/include",
 					"$(LLVM_BUILD_DIR)/include",
@@ -1072,8 +1071,6 @@
 					"$(inherited)",
 					"$(CAPSTONE_DIR)/lib",
 				);
-				OTHER_CFLAGS = "";
-				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				USER_HEADER_SEARCH_PATHS = "";
 			};
@@ -1082,11 +1079,9 @@
 		DCCD51F61AEC45B300AAF640 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"__STDC_CONSTANT_MACROS\n__STDC_LIMIT_MACROS",
 				);
-				GCC_VERSION = "";
 				HEADER_SEARCH_PATHS = (
 					"$(LLVM_SRC_DIR)/include",
 					"$(LLVM_BUILD_DIR)/include",
@@ -1096,8 +1091,6 @@
 					"$(inherited)",
 					"$(CAPSTONE_DIR)/lib",
 				);
-				OTHER_CFLAGS = "";
-				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				USER_HEADER_SEARCH_PATHS = "";
 			};

--- a/fcd.xcodeproj/project.pbxproj
+++ b/fcd.xcodeproj/project.pbxproj
@@ -926,7 +926,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				LLVM_BIN_DIR = "$(LLVM_BUILD_DIR)";
-				LLVM_BUILD_DIR = "$(HOME)/Projets/clang+llvm-4.0.0-rc1-x86_64-apple-darwin";
+				LLVM_BUILD_DIR = "$(HOME)/Projets/clang+llvm-4.0.0-rc2-x86_64-apple-darwin";
 				LLVM_SRC_DIR = "$(LLVM_BUILD_DIR)";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -974,7 +974,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				LLVM_BIN_DIR = "$(LLVM_BUILD_DIR)";
-				LLVM_BUILD_DIR = "$(HOME)/Projets/clang+llvm-4.0.0-rc1-x86_64-apple-darwin";
+				LLVM_BUILD_DIR = "$(HOME)/Projets/clang+llvm-4.0.0-rc2-x86_64-apple-darwin";
 				LLVM_SRC_DIR = "$(LLVM_BUILD_DIR)";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;

--- a/fcd.xcodeproj/project.pbxproj
+++ b/fcd.xcodeproj/project.pbxproj
@@ -224,6 +224,7 @@
 		DC84358E1CA8E59600DE93C6 /* print.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = print.h; sourceTree = "<group>"; };
 		DC8435901CA8E96B00DE93C6 /* type_printer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = type_printer.cpp; sourceTree = "<group>"; };
 		DC8435911CA8E96B00DE93C6 /* type_printer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = type_printer.h; sourceTree = "<group>"; };
+		DC878FAE1E383B2F00D78A1F /* CodeGenTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CodeGenTypes.h; sourceTree = "<group>"; };
 		DC89D8551ACDB2A00001C92D /* x86.emulator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = x86.emulator.cpp; path = ../cpu/x86.emulator.cpp; sourceTree = "<group>"; };
 		DC89D8561ACDB2A00001C92D /* x86.emulator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = x86.emulator.h; path = ../cpu/x86.emulator.h; sourceTree = "<group>"; };
 		DC93E3731E5F4DC90094A0CB /* pass_congruence.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pass_congruence.cpp; sourceTree = "<group>"; };
@@ -292,7 +293,6 @@
 		DCCEC7841D773122004D341E /* libclangIndex.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangIndex.a; path = "$(CLANG_BIN_DIR)/lib/libclangIndex.a"; sourceTree = "<absolute>"; };
 		DCCEC7861D773147004D341E /* libclangDriver.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangDriver.a; path = "$(CLANG_BIN_DIR)/lib/libclangDriver.a"; sourceTree = "<absolute>"; };
 		DCCEC7881D773167004D341E /* libclangParse.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangParse.a; path = "$(CLANG_BIN_DIR)/lib/libclangParse.a"; sourceTree = "<absolute>"; };
-		DCCEC78B1D79CB37004D341E /* CodeGenTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CodeGenTypes.h; sourceTree = "<group>"; };
 		DCCEC78C1D79D0D4004D341E /* libclangCodeGen.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libclangCodeGen.a; path = "$(CLANG_BIN_DIR)/lib/libclangCodeGen.a"; sourceTree = "<absolute>"; };
 		DCCEC78E1D79D158004D341E /* libLLVMCoverage.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libLLVMCoverage.a; path = "$(LLVM_BIN_DIR)/lib/libLLVMCoverage.a"; sourceTree = "<absolute>"; };
 		DCD8B1811BAE1A3F00968A83 /* flat_binary.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = flat_binary.cpp; sourceTree = "<group>"; };
@@ -678,7 +678,7 @@
 		DCCEC78A1D79CB15004D341E /* Clang */ = {
 			isa = PBXGroup;
 			children = (
-				DCCEC78B1D79CB37004D341E /* CodeGenTypes.h */,
+				DC878FAE1E383B2F00D78A1F /* CodeGenTypes.h */,
 			);
 			name = Clang;
 			path = clang;
@@ -886,7 +886,7 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CAPSTONE_DIR = /usr/local/Cellar/capstone/3.0.4;
 				CLANG_BIN_DIR = "$(LLVM_BIN_DIR)";
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++14";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -919,7 +919,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				LLVM_BIN_DIR = "$(LLVM_BUILD_DIR)";
-				LLVM_BUILD_DIR = "$(HOME)/Projets/clang+llvm-3.9.0-x86_64-apple-darwin";
+				LLVM_BUILD_DIR = "$(HOME)/Projets/clang+llvm-4.0.0-rc1-x86_64-apple-darwin";
 				LLVM_SRC_DIR = "$(LLVM_BUILD_DIR)";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -940,7 +940,7 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CAPSTONE_DIR = /usr/local/Cellar/capstone/3.0.4;
 				CLANG_BIN_DIR = "$(LLVM_BIN_DIR)";
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++14";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -970,7 +970,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				LLVM_BIN_DIR = "$(LLVM_BUILD_DIR)";
-				LLVM_BUILD_DIR = "$(HOME)/Projets/clang+llvm-3.9.0-x86_64-apple-darwin";
+				LLVM_BUILD_DIR = "$(HOME)/Projets/clang+llvm-4.0.0-rc1-x86_64-apple-darwin";
 				LLVM_SRC_DIR = "$(LLVM_BUILD_DIR)";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
@@ -1022,7 +1022,6 @@
 		DCAFCA351AD6F2110095E89E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++14";
 				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = NO;
 				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = NO;
 				GCC_ENABLE_CPP_RTTI = NO;
@@ -1049,7 +1048,6 @@
 					"$(LLVM_BIN_DIR)/lib",
 					"$(CAPSTONE_DIR)/lib",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				USER_HEADER_SEARCH_PATHS = "";
 			};
@@ -1058,7 +1056,6 @@
 		DCCD51F51AEC45B300AAF640 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -1074,7 +1071,6 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(CAPSTONE_DIR)/lib",
-					/usr/local/Cellar/capstone/3.0.4/lib,
 				);
 				OTHER_CFLAGS = "";
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
@@ -1099,7 +1095,6 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(CAPSTONE_DIR)/lib",
-					/usr/local/Cellar/capstone/3.0.4/lib,
 				);
 				OTHER_CFLAGS = "";
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";

--- a/fcd/ast/pass_backend.h
+++ b/fcd/ast/pass_backend.h
@@ -54,7 +54,7 @@ public:
 	AstBackEnd();
 	~AstBackEnd();
 	
-	inline virtual const char* getPassName() const override
+	inline virtual llvm::StringRef getPassName() const override
 	{
 		return "AST Back-End";
 	}

--- a/fcd/ast/pre_ast_cfg.h
+++ b/fcd/ast/pre_ast_cfg.h
@@ -130,7 +130,7 @@ struct PreAstBasicBlockRegionTraits
 template<typename Iterator, typename Transformer>
 struct PreAstBasicBlockIterator : public std::iterator<std::input_iterator_tag, NOT_NULL(PreAstBasicBlock)>
 {
-	Iterator base;
+	typename std::remove_reference<Iterator>::type base;
 	Transformer transformer;
 	
 	PreAstBasicBlockIterator(Iterator base, Transformer&& transformer)
@@ -231,12 +231,12 @@ struct llvm::GraphTraits<llvm::Inverse<PreAstBasicBlock*>>
 	
 	static ChildIteratorType child_begin(NodeRef node)
 	{
-		return makePredecessorIterator(node->successors.begin());
+		return makePredecessorIterator(node->predecessors.begin());
 	}
 	
 	static ChildIteratorType child_end(NodeRef node)
 	{
-		return makePredecessorIterator(node->successors.end());
+		return makePredecessorIterator(node->predecessors.end());
 	}
 };
 

--- a/fcd/callconv/anyarch_anycc.cpp
+++ b/fcd/callconv/anyarch_anycc.cpp
@@ -357,7 +357,7 @@ bool CallingConvention_AnyArch_AnyCC::analyzeFunction(ParameterRegistry &registr
 		return false;
 	}
 	
-	auto regs = static_cast<Argument*>(func.arg_begin());
+	auto regs = &*func.arg_begin();
 	unordered_map<const TargetRegisterInfo*, ModRefInfo> resultMap;
 	
 	// Find all GEPs

--- a/fcd/callconv/cc_common.cpp
+++ b/fcd/callconv/cc_common.cpp
@@ -93,9 +93,9 @@ vector<const TargetRegisterInfo*> ipaFindUsedReturns(ParameterRegistry& registry
 				continue;
 			}
 			
-			auto parentArgs = static_cast<Argument*>(parentFunction->arg_begin());
+			auto parentArgs = &*parentFunction->arg_begin();
 			auto pointerType = dyn_cast<PointerType>(parentArgs->getType());
-			assert(pointerType != nullptr && pointerType->getTypeAtIndex(int(0))->getStructName() == "struct.x86_regs");
+			assert(pointerType != nullptr && pointerType->getElementType()->getStructName() == "struct.x86_regs");
 			(void) pointerType;
 			
 			visited.clear();

--- a/fcd/callconv/params_registry.cpp
+++ b/fcd/callconv/params_registry.cpp
@@ -55,7 +55,7 @@ namespace
 				
 				sort(callingConventions.begin(), callingConventions.end(), [](OptionInfo& a, OptionInfo& b)
 				{
-					return strcmp(a.Name, b.Name) < 0;
+					return a.Name < b.Name;
 				});
 				
 				callingConventions.emplace(callingConventions.begin(), nullptr, nullptr);
@@ -76,12 +76,12 @@ namespace
 			return static_cast<unsigned>(ccs().size());
 		}
 		
-		virtual const char* getOption(unsigned n) const override
+		virtual StringRef getOption(unsigned n) const override
 		{
 			return ccs().at(n).Name;
 		}
 		
-		virtual const char* getDescription(unsigned n) const override
+		virtual StringRef getDescription(unsigned n) const override
 		{
 			return ccs().at(n).HelpStr;
 		}
@@ -367,7 +367,7 @@ void ParameterRegistry::getAnalysisUsage(AnalysisUsage &au) const
 	ModulePass::getAnalysisUsage(au);
 }
 
-const char* ParameterRegistry::getPassName() const
+StringRef ParameterRegistry::getPassName() const
 {
 	return "Parameter Registry";
 }

--- a/fcd/callconv/params_registry.h
+++ b/fcd/callconv/params_registry.h
@@ -261,7 +261,7 @@ public:
 	llvm::MemorySSA* getMemorySSA(llvm::Function& function);
 	
 	virtual void getAnalysisUsage(llvm::AnalysisUsage& au) const override;
-	virtual const char* getPassName() const override;
+	virtual llvm::StringRef getPassName() const override;
 	virtual bool doInitialization(llvm::Module& module) override;
 	virtual bool runOnModule(llvm::Module& m) override;
 };

--- a/fcd/callconv/x86_64_systemv.cpp
+++ b/fcd/callconv/x86_64_systemv.cpp
@@ -270,9 +270,9 @@ bool CallingConvention_x86_64_systemv::analyzeFunction(ParameterRegistry &regist
 	// Identify register GEPs.
 	// (assume x86 regs as first parameter)
 	assert(function.arg_size() == 1);
-	auto regs = static_cast<Argument*>(function.arg_begin());
+	auto regs = function.arg_begin();
 	auto pointerType = dyn_cast<PointerType>(regs->getType());
-	assert(pointerType != nullptr && pointerType->getTypeAtIndex(int(0))->getStructName() == "struct.x86_regs");
+	assert(pointerType != nullptr && pointerType->getElementType()->getStructName() == "struct.x86_regs");
 	(void) pointerType;
 	
 	unordered_multimap<const TargetRegisterInfo*, GetElementPtrInst*> geps;

--- a/fcd/clang/CodeGenTypes.h
+++ b/fcd/clang/CodeGenTypes.h
@@ -14,15 +14,14 @@
 #ifndef LLVM_CLANG_LIB_CODEGEN_CODEGENTYPES_H
 #define LLVM_CLANG_LIB_CODEGEN_CODEGENTYPES_H
 
-#include "clang/AST/GlobalDecl.h"
+#include "clang/Basic/ABI.h"
 #include "clang/CodeGen/CGFunctionInfo.h"
+#include "clang/Sema/Sema.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/IR/Module.h"
-#include <vector>
 
 namespace llvm {
 class FunctionType;
-class Module;
 class DataLayout;
 class Type;
 class LLVMContext;
@@ -30,6 +29,10 @@ class StructType;
 }
 
 namespace clang {
+// --- added for fcd
+class CallArgList;
+class FunctionArgList;
+// ---
 class ASTContext;
 template <typename> class CanQual;
 class CXXConstructorDecl;
@@ -47,6 +50,7 @@ class TagDecl;
 class TargetInfo;
 class Type;
 typedef CanQual<Type> CanQualType;
+class GlobalDecl;
 
 namespace CodeGen {
 class ABIInfo;
@@ -54,8 +58,6 @@ class CGCXXABI;
 class CGRecordLayout;
 class CodeGenModule;
 class RequiredArgs;
-class CallArgList;
-class FunctionArgList;
 
 enum class StructorType {
   Complete, // constructor or destructor
@@ -352,6 +354,10 @@ public:  // These are internal details of CGT that shouldn't be used externally.
   /// IsZeroInitializable - Return whether a type can be
   /// zero-initialized (in the C++ sense) with an LLVM zeroinitializer.
   bool isZeroInitializable(QualType T);
+
+  /// Check if the pointer type can be zero-initialized (in the C++ sense)
+  /// with an LLVM zeroinitializer.
+  bool isPointerZeroInitializable(QualType T);
 
   /// IsZeroInitializable - Return whether a record type can be
   /// zero-initialized (in the C++ sense) with an LLVM zeroinitializer.

--- a/fcd/clang/LICENSE.TXT
+++ b/fcd/clang/LICENSE.TXT
@@ -1,0 +1,63 @@
+==============================================================================
+LLVM Release License
+==============================================================================
+University of Illinois/NCSA
+Open Source License
+
+Copyright (c) 2007-2016 University of Illinois at Urbana-Champaign.
+All rights reserved.
+
+Developed by:
+
+    LLVM Team
+
+    University of Illinois at Urbana-Champaign
+
+    http://llvm.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal with
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimers.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimers in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the names of the LLVM Team, University of Illinois at
+      Urbana-Champaign, nor the names of its contributors may be used to
+      endorse or promote products derived from this Software without specific
+      prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+SOFTWARE.
+
+==============================================================================
+The LLVM software contains code written by third parties.  Such software will
+have its own individual LICENSE.TXT file in the directory in which it appears.
+This file will describe the copyrights, license, and restrictions which apply
+to that code.
+
+The disclaimer of warranty in the University of Illinois Open Source License
+applies to all code in the LLVM Distribution, and nothing in any of the
+other licenses gives permission to use the names of the LLVM Team or the
+University of Illinois to endorse or promote products derived from this
+Software.
+
+The following pieces of software have additional or alternate copyrights,
+licenses, and/or restrictions:
+
+Program             Directory
+-------             ---------
+<none yet>
+

--- a/fcd/codegen/code_generator.cpp
+++ b/fcd/codegen/code_generator.cpp
@@ -352,7 +352,7 @@ void CodeGenerator::inlineFunction(Function *target, Function *toInline, ArrayRe
 	getModuleLevelValueChanges(valueMap, targetModule);
 	for (Value* parameter : parameters)
 	{
-		valueMap[static_cast<Argument*>(iter)] = parameter;
+		valueMap[&*iter] = parameter;
 		++iter;
 	}
 	
@@ -363,7 +363,7 @@ void CodeGenerator::inlineFunction(Function *target, Function *toInline, ArrayRe
 	// Stitch blocks together
 	Function::iterator firstNewBlock = blockBeforeInstruction;
 	++firstNewBlock;
-	BranchInst::Create(static_cast<BasicBlock*>(firstNewBlock), static_cast<BasicBlock*>(blockBeforeInstruction));
+	BranchInst::Create(&*firstNewBlock, &*blockBeforeInstruction);
 	
 	// Redirect returns
 	BasicBlock* nextBlock = blockMap.blockToInstruction(nextAddress);

--- a/fcd/codegen/translation_context.cpp
+++ b/fcd/codegen/translation_context.cpp
@@ -256,7 +256,7 @@ Function* TranslationContext::createFunction(uint64_t baseAddress)
 	AddressToBlock blockMap(*fn);
 	BasicBlock* entry = &fn->back();
 	
-	Argument* registers = static_cast<Argument*>(fn->arg_begin());
+	Argument* registers = &*fn->arg_begin();
 	auto flags = new AllocaInst(irgen->getFlagsTy(), "flags", entry);
 	
 	ArrayRef<Value*> ipGepIndices = irgen->getIpOffset();

--- a/fcd/cpu/x86_register_map.cpp
+++ b/fcd/cpu/x86_register_map.cpp
@@ -33,7 +33,7 @@ namespace
 		{
 			if (registerId != X86_REG_INVALID)
 			{
-				TargetRegisterInfo result = { offset, size, {0, fieldOffset, 0}, name, registerId };
+				TargetRegisterInfo result = { offset, size, {fieldOffset, 0}, name, registerId };
 				info.push_back(result);
 			}
 		}
@@ -42,7 +42,7 @@ namespace
 		{
 			if (registerId != X86_REG_INVALID)
 			{
-				TargetRegisterInfo result = { offset, size, {0, fieldOffset, 0}, name, registerId };
+				TargetRegisterInfo result = { offset, size, {fieldOffset, 0}, name, registerId };
 				info.push_back(result);
 			}
 		}

--- a/fcd/cpu/x86_register_map.cpp
+++ b/fcd/cpu/x86_register_map.cpp
@@ -33,7 +33,7 @@ namespace
 		{
 			if (registerId != X86_REG_INVALID)
 			{
-				TargetRegisterInfo result = { offset, size, {fieldOffset, 0}, name, registerId };
+				TargetRegisterInfo result = { offset, 0, size, {fieldOffset, 0}, name, registerId };
 				info.push_back(result);
 			}
 		}
@@ -42,7 +42,7 @@ namespace
 		{
 			if (registerId != X86_REG_INVALID)
 			{
-				TargetRegisterInfo result = { offset, size, {fieldOffset, 0}, name, registerId };
+				TargetRegisterInfo result = { offset, offset - this->offset, size, {fieldOffset, 0}, name, registerId };
 				info.push_back(result);
 			}
 		}

--- a/fcd/executables/elf_executable.cpp
+++ b/fcd/executables/elf_executable.cpp
@@ -687,7 +687,7 @@ namespace
 		assert(end >= begin);
 		
 		using namespace std;
-		auto executable = make_unique<ElfExecutable<Types>>(begin, end);
+		auto executable = std::make_unique<ElfExecutable<Types>>(begin, end);
 		
 		deque<const Elf_Phdr*> dynamics;
 		deque<const Elf_Shdr*> sections;

--- a/fcd/executables/executable.cpp
+++ b/fcd/executables/executable.cpp
@@ -127,12 +127,12 @@ namespace
 			return static_cast<unsigned>(factories().size());
 		}
 		
-		virtual const char* getOption(unsigned n) const override
+		virtual StringRef getOption(unsigned n) const override
 		{
 			return factories().at(n).Name;
 		}
 		
-		virtual const char* getDescription(unsigned n) const override
+		virtual StringRef getDescription(unsigned n) const override
 		{
 			return factories().at(n).HelpStr;
 		}
@@ -148,7 +148,7 @@ namespace
 			ci_string ciArgVal(argVal.begin(), argVal.end());
 			for (const auto& info : factories())
 			{
-				if (ciArgVal == info.Name)
+				if (ciArgVal.c_str() == info.Name)
 				{
 					value = info.factory.getValue();
 					return false;

--- a/fcd/executables/flat_binary.cpp
+++ b/fcd/executables/flat_binary.cpp
@@ -64,6 +64,6 @@ FlatBinaryExecutableFactory::FlatBinaryExecutableFactory()
 
 ErrorOr<unique_ptr<Executable>> FlatBinaryExecutableFactory::parse(const uint8_t* begin, const uint8_t* end)
 {
-	unique_ptr<Executable> executable = make_unique<FlatBinary>(begin, end, flatOrigin);
+	auto executable = std::make_unique<FlatBinary>(begin, end, flatOrigin);
 	return move(executable);
 }

--- a/fcd/header_decls.cpp
+++ b/fcd/header_decls.cpp
@@ -182,7 +182,7 @@ unique_ptr<HeaderDeclarations> HeaderDeclarations::create(llvm::Module& module, 
 		auto diagPrinter = new TextDiagnosticPrinter(errors, diagOpts.get());
 		auto diags = CompilerInstance::createDiagnostics(diagOpts.release(), diagPrinter);
 		
-		unique_ptr<CompilerInvocation> clang;
+		shared_ptr<CompilerInvocation> clang;
 		{
 			// It might seem lazy to use CreateFromArgs to specify frameworks, but no one has been able to tell me how to
 			// do it without using -framework.
@@ -242,7 +242,7 @@ unique_ptr<HeaderDeclarations> HeaderDeclarations::create(llvm::Module& module, 
 			frontendOpts.Inputs.emplace_back(includeBuffer.release(), IK_C);
 			
 			auto pch = std::make_shared<PCHContainerOperations>();
-			auto tu = ASTUnit::LoadFromCompilerInvocation(move(clang), pch, diags, new FileManager(FileSystemOptions()), true);
+			auto tu = ASTUnit::LoadFromCompilerInvocation(clang, pch, diags, new FileManager(FileSystemOptions()), true);
 			if (diagPrinter->getNumErrors() == 0)
 			{
 				if (tu)

--- a/fcd/main.cpp
+++ b/fcd/main.cpp
@@ -537,7 +537,6 @@ namespace
 				phaseTwo.add(new ExecutableWrapper(executable));
 				phaseTwo.add(createParameterRegistryPass());
 				phaseTwo.add(createExternalAAWrapperPass(&Main::aliasAnalysisHooks));
-				phaseTwo.add(createGVNPass());
 				phaseTwo.add(createDeadStoreEliminationPass());
 				phaseTwo.add(createInstructionCombiningPass());
 				phaseTwo.add(createCFGSimplificationPass());

--- a/fcd/pass_argrec.cpp
+++ b/fcd/pass_argrec.cpp
@@ -37,7 +37,7 @@ Value* ArgumentRecovery::getRegisterPtr(Function& fn)
 		return nullptr;
 	}
 	
-	auto arg = static_cast<Argument*>(fn.arg_begin());
+	auto arg = &*fn.arg_begin();
 	registerPtr[&fn] = arg;
 	return arg;
 }
@@ -144,7 +144,7 @@ Value* ArgumentRecovery::createReturnValue(Function &function, const CallInforma
 		gep->insertBefore(insertionPoint);
 		result = new LoadInst(gep, "", insertionPoint);
 		
-		Type* gepElementType = gep->getType()->getElementType();
+		Type* gepElementType = cast<PointerType>(gep->getType())->getElementType();
 		if (gepElementType != returnType)
 		{
 			if (returnType->isIntegerTy())
@@ -203,9 +203,9 @@ void ArgumentRecovery::updateFunctionBody(Function& oldFunction, Function& newFu
 	oldFunction.deleteBody();
 	
 	// Create a register structure at the beginning of the function and copy arguments to it.
-	Argument* oldArg0 = static_cast<Argument*>(oldFunction.arg_begin());
+	Argument* oldArg0 = &*oldFunction.arg_begin();
 	Type* registerStruct = oldArg0->getType()->getPointerElementType();
-	Instruction* insertionPoint = static_cast<Instruction*>(newFunction.begin()->begin());
+	Instruction* insertionPoint = &*newFunction.begin()->begin();
 	AllocaInst* newRegisters = new AllocaInst(registerStruct, "registers", insertionPoint);
 	md::setRegisterStruct(*newRegisters);
 	oldArg0->replaceAllUsesWith(newRegisters);

--- a/fcd/pass_fixind.cpp
+++ b/fcd/pass_fixind.cpp
@@ -74,7 +74,7 @@ namespace
 				if (auto call = dyn_cast<CallInst>(user))
 				{
 					Value* destination = call->getArgOperand(2);
-					auto intptrDestination = CastInst::Create(CastInst::IntToPtr, destination, intptrTy, "", call);
+					auto intptrDestination = CastInst::Create(CastInst::BitCast, destination, intptrTy, "", call);
 					CallInst::Create(indirectJump, { intptrDestination }, "", call);
 					call->eraseFromParent();
 				}

--- a/fcd/pass_intnarrowing.cpp
+++ b/fcd/pass_intnarrowing.cpp
@@ -48,7 +48,7 @@ namespace
 		{
 		}
 		
-		virtual const char* getPassName() const override
+		virtual StringRef getPassName() const override
 		{
 			return "Narrow Integers";
 		}
@@ -84,7 +84,7 @@ namespace
 					Instruction* location = nullptr;
 					if (auto valueAsPhi = dyn_cast<PHINode>(thatValue))
 					{
-						location = static_cast<Instruction*>(valueAsPhi->getParent()->getFirstInsertionPt());
+						location = &*valueAsPhi->getParent()->getFirstInsertionPt();
 					}
 					else if (auto valueAsInst = dyn_cast<Instruction>(thatValue))
 					{
@@ -92,7 +92,7 @@ namespace
 					}
 					else
 					{
-						location = static_cast<Instruction*>(currentFunction->getEntryBlock().getFirstInsertionPt());
+						location = &*currentFunction->getEntryBlock().getFirstInsertionPt();
 					}
 					value = CastInst::Create(Instruction::Trunc, thatValue, truncatedType, "", location);
 				}

--- a/fcd/pass_locals.cpp
+++ b/fcd/pass_locals.cpp
@@ -838,7 +838,7 @@ namespace
 		{
 		}
 		
-		virtual const char* getPassName() const override
+		virtual StringRef getPassName() const override
 		{
 			return "Identify locals";
 		}
@@ -853,7 +853,7 @@ namespace
 			
 			auto arg = fn.arg_begin();
 			advance(arg, stackPointerIndex->getLimitedValue());
-			return static_cast<Argument*>(arg);
+			return &*arg;
 		}
 		
 		bool analyzeObject(Value& base, bool& hasCastInst, map<int64_t, Instruction*>& constantOffsets, map<int64_t, Instruction*>& variableOffsetStrides)
@@ -1076,7 +1076,7 @@ namespace
 			if (auto root = readObject(*stackPointer, nullptr))
 			if (auto llvmFrame = LlvmStackFrame::representObject(fn.getContext(), *dl, cast<StructureStackObject>(*root)))
 			{
-				auto allocaInsert = static_cast<Instruction*>(fn.getEntryBlock().getFirstInsertionPt());
+				auto allocaInsert = &*fn.getEntryBlock().getFirstInsertionPt();
 				Type* naiveType = llvmFrame->getNaiveType(*root);
 				AllocaInst* stackFrame = new AllocaInst(naiveType, "stackframe", allocaInsert);
 				md::setStackFrame(*stackFrame);

--- a/fcd/pass_memssa_dle.cpp
+++ b/fcd/pass_memssa_dle.cpp
@@ -25,7 +25,7 @@ namespace
 		{
 		}
 		
-		virtual const char* getPassName() const override
+		virtual StringRef getPassName() const override
 		{
 			return "Dead Load Elimination";
 		}

--- a/fcd/pass_regptrpromotion.cpp
+++ b/fcd/pass_regptrpromotion.cpp
@@ -41,7 +41,7 @@ namespace
 				assert(f.arg_size() == 1);
 				
 				// Copy arguments to independent list to avoid iterating while modifying.
-				auto firstArg = static_cast<Argument*>(f.arg_begin());
+				auto firstArg = &*f.arg_begin();
 				SmallVector<User*, 16> users(firstArg->user_begin(), firstArg->user_end());
 				for (auto user : users)
 				{

--- a/fcd/python/python_context.cpp
+++ b/fcd/python/python_context.cpp
@@ -62,7 +62,7 @@ namespace
 		{
 		}
 		
-		virtual const char* getPassName() const override
+		virtual StringRef getPassName() const override
 		{
 			return name.c_str();
 		}
@@ -84,7 +84,7 @@ namespace
 		{
 		}
 		
-		virtual const char* getPassName() const override
+		virtual StringRef getPassName() const override
 		{
 			return name.c_str();
 		}

--- a/fcd/targetinfo.cpp
+++ b/fcd/targetinfo.cpp
@@ -53,11 +53,12 @@ GetElementPtrInst* TargetInfo::getRegister(llvm::Value *registerStruct, const Ta
 		return nullptr;
 	}
 	
-	SmallVector<Value*, 4> indices;
 	LLVMContext& ctx = registerStruct->getContext();
 	IntegerType* int32 = Type::getInt32Ty(ctx);
 	IntegerType* int64 = Type::getInt64Ty(ctx);
-	CompositeType* currentType = cast<CompositeType>(registerStruct->getType());
+	
+	SmallVector<Value*, 4> indices { ConstantInt::get(int64, 0) };
+	CompositeType* currentType = cast<CompositeType>(cast<PointerType>(registerStruct->getType())->getElementType());
 	for (unsigned offset : selected->gepOffsets)
 	{
 		IntegerType* constantType = isa<StructType>(currentType) ? int32 : int64;

--- a/fcd/targetinfo.h
+++ b/fcd/targetinfo.h
@@ -22,6 +22,7 @@
 struct TargetRegisterInfo
 {
 	size_t offset;
+	size_t subOffset;
 	size_t size;
 	llvm::SmallVector<unsigned, 4> gepOffsets;
 	std::string name;
@@ -81,7 +82,7 @@ public:
 		return nullptr;
 	}
 	
-	llvm::GetElementPtrInst* getRegister(llvm::Value* registerStruct, const TargetRegisterInfo& info) const;
+	llvm::Instruction* getRegister(llvm::Value* registerStruct, const TargetRegisterInfo& info, llvm::Instruction& insertionPoint) const;
 	
 	const TargetRegisterInfo* registerInfo(unsigned registerId) const;
 	const TargetRegisterInfo* registerInfo(const llvm::Value& value) const;


### PR DESCRIPTION
This PR builds fcd against LLVM 4.0.

The merge to master is expected to happen when 4.0 reaches stable status. At the same time, a "llvm-3.9"/"v2" tag will be created against the last master revision that builds with LLVM 3.9.