### PR TITLE
Header ordering and warnings

### DIFF
--- a/fcd/ast/ast_context.cpp
+++ b/fcd/ast/ast_context.cpp
@@ -331,7 +331,7 @@ public:
 					negated = right;
 				}
 			}
-			else if (auto constant = dyn_cast<ConstantInt>(inst.getOperand(1)))
+			else if ((constant = dyn_cast<ConstantInt>(inst.getOperand(1))))
 			{
 				if (constant->isAllOnesValue())
 				{
@@ -755,7 +755,6 @@ const ExpressionType& AstContext::getType(Type &type)
 			structType = &createStructure(move(name));
 			for (unsigned i = 0; i < structure->getNumElements(); ++i)
 			{
-				string name;
 				if (module != nullptr)
 				{
 					name = md::getRecoveredReturnFieldName(*module, *structure, i).str();

--- a/fcd/ast/ast_context.cpp
+++ b/fcd/ast/ast_context.cpp
@@ -331,7 +331,7 @@ public:
 					negated = right;
 				}
 			}
-			else if ((constant = dyn_cast<ConstantInt>(inst.getOperand(1))))
+			else if (auto constant = dyn_cast<ConstantInt>(inst.getOperand(1)))
 			{
 				if (constant->isAllOnesValue())
 				{

--- a/fcd/ast/expression_type.h
+++ b/fcd/ast/expression_type.h
@@ -161,9 +161,9 @@ public:
 	const ExpressionTypeField& operator[](size_t index) const { return fields[index]; }
 	size_t size() const { return fields.size(); }
 	
-	void append(const ExpressionType& type, std::string name)
+	void append(const ExpressionType& type, std::string fieldName)
 	{
-		fields.emplace_back(type, std::move(name));
+		fields.emplace_back(type, std::move(fieldName));
 	}
 	
 	virtual void print(llvm::raw_ostream& os) const override;

--- a/fcd/ast/expression_type.h
+++ b/fcd/ast/expression_type.h
@@ -10,7 +10,6 @@
 #ifndef expression_type_hpp
 #define expression_type_hpp
 
-
 #include <llvm/ADT/StringRef.h>
 #include <llvm/Support/raw_ostream.h>
 

--- a/fcd/ast/expression_use.h
+++ b/fcd/ast/expression_use.h
@@ -10,7 +10,6 @@
 #ifndef use_list_hpp
 #define use_list_hpp
 
-
 #include <llvm/ADT/iterator_range.h>
 #include <llvm/ADT/PointerIntPair.h>
 #include <llvm/Support/raw_ostream.h>

--- a/fcd/ast/expressions.cpp
+++ b/fcd/ast/expressions.cpp
@@ -10,8 +10,8 @@
 #include "ast_context.h"
 #include "expressions.h"
 #include "function.h"
-#include "statements.h"
 #include "print.h"
+#include "statements.h"
 
 #include <llvm/Support/raw_os_ostream.h>
 

--- a/fcd/ast/expressions.cpp
+++ b/fcd/ast/expressions.cpp
@@ -284,9 +284,9 @@ TokenExpression::TokenExpression(AstContext& ctx, unsigned uses, const Expressio
 
 bool TokenExpression::operator==(const Expression& that) const
 {
-	if (auto token = llvm::dyn_cast<TokenExpression>(&that))
+	if (auto tokenExpr = llvm::dyn_cast<TokenExpression>(&that))
 	{
-		return strcmp(this->token, token->token) == 0;
+		return strcmp(this->token, tokenExpr->token) == 0;
 	}
 	return false;
 }

--- a/fcd/ast/pass.cpp
+++ b/fcd/ast/pass.cpp
@@ -49,14 +49,14 @@ void AstModulePass::run(deque<unique_ptr<FunctionNode>>& fn)
 
 void AstFunctionPass::doRun(deque<unique_ptr<FunctionNode>>& list)
 {
-	for (unique_ptr<FunctionNode>& fn : list)
+	for (unique_ptr<FunctionNode>& funcNode : list)
 	{
-		if (runOnDeclarations || fn->hasBody())
+		if (runOnDeclarations || funcNode->hasBody())
 		{
-			PrettyStackTraceFormat runPass("Running AST pass \"%s\" on function \"%s\"", getName(), string(fn->getFunction().getName()).c_str());
+			PrettyStackTraceFormat runPass("Running AST pass \"%s\" on function \"%s\"", getName(), string(funcNode->getFunction().getName()).c_str());
 			
-			this->fn = fn.get();
-			doRun(*fn);
+			this->fn = funcNode.get();
+			doRun(*funcNode);
 		}
 	}
 }

--- a/fcd/ast/pass_backend.cpp
+++ b/fcd/ast/pass_backend.cpp
@@ -8,8 +8,8 @@
 //
 
 #include "metadata.h"
-#include "passes.h"
 #include "pass_backend.h"
+#include "passes.h"
 #include "pre_ast_cfg.h"
 
 #include <llvm/ADT/PostOrderIterator.h>

--- a/fcd/ast/pre_ast_cfg.cpp
+++ b/fcd/ast/pre_ast_cfg.cpp
@@ -75,11 +75,11 @@ PreAstBasicBlock& PreAstBasicBlock::operator=(PreAstBasicBlock&& that)
 	return *this;
 }
 
-void PreAstBasicBlock::swap(PreAstBasicBlock& block)
+void PreAstBasicBlock::swap(PreAstBasicBlock& other)
 {
 	auto temporary = move(*this);
-	*this = move(block);
-	block = move(temporary);
+	*this = move(other);
+	other = move(temporary);
 }
 
 void PreAstBasicBlock::printAsOperand(llvm::raw_ostream& os, bool printType)

--- a/fcd/ast/pre_ast_cfg.h
+++ b/fcd/ast/pre_ast_cfg.h
@@ -14,11 +14,11 @@
 
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/SmallVector.h>
-#include <llvm/IR/Function.h>
 #include <llvm/Analysis/DominanceFrontier.h>
 #include <llvm/Analysis/LoopInfo.h>
 #include <llvm/IR/BasicBlock.h>
 #include <llvm/IR/Dominators.h>
+#include <llvm/IR/Function.h>
 #include <llvm/Support/GenericDomTree.h>
 #include <llvm/Support/GenericDomTreeConstruction.h>
 

--- a/fcd/ast/print.cpp
+++ b/fcd/ast/print.cpp
@@ -490,9 +490,10 @@ void StatementPrintVisitor::visitCall(const CallExpression& call)
 	outSS << '(';
 	auto iter = call.params_begin();
 	auto end = call.params_end();
+	string separator = "";
 	for (; iter != end; ++iter)
 	{
-		outSS << ", ";
+		outSS << separator;
 		const string& paramName = funcType[paramIndex].name;
 		if (paramName != "")
 		{
@@ -501,6 +502,7 @@ void StatementPrintVisitor::visitCall(const CallExpression& call)
 		}
 		visit(*iter->getUse());
 		outSS << take(os);
+		separator = ", ";
 	}
 	outSS << ')';
 	swap(outSS.str(), os.str());

--- a/fcd/ast/print.cpp
+++ b/fcd/ast/print.cpp
@@ -490,29 +490,17 @@ void StatementPrintVisitor::visitCall(const CallExpression& call)
 	outSS << '(';
 	auto iter = call.params_begin();
 	auto end = call.params_end();
-	if (iter != end)
+	for (; iter != end; ++iter)
 	{
+		outSS << ", ";
 		const string& paramName = funcType[paramIndex].name;
 		if (paramName != "")
 		{
 			outSS << paramName << '=';
 			paramIndex++;
 		}
-		
 		visit(*iter->getUse());
 		outSS << take(os);
-		for (++iter; iter != end; ++iter)
-		{
-			outSS << ", ";
-			const string& paramName = funcType[paramIndex].name;
-			if (paramName != "")
-			{
-				outSS << paramName << '=';
-				paramIndex++;
-			}
-			visit(*iter->getUse());
-			outSS << take(os);
-		}
 	}
 	outSS << ')';
 	swap(outSS.str(), os.str());

--- a/fcd/ast/statements.cpp
+++ b/fcd/ast/statements.cpp
@@ -7,10 +7,10 @@
 // license. See LICENSE.md for details.
 //
 
-#include "statements.h"
 #include "function.h"
-#include "visitor.h"
 #include "print.h"
+#include "statements.h"
+#include "visitor.h"
 
 #include <llvm/Support/raw_os_ostream.h>
 

--- a/fcd/ast/statements.h
+++ b/fcd/ast/statements.h
@@ -10,10 +10,11 @@
 #ifndef fcd__ast_statements_h
 #define fcd__ast_statements_h
 
-#include <iterator>
 #include "expression_use.h"
 #include "expressions.h"
 #include "not_null.h"
+
+#include <iterator>
 
 class Statement;
 

--- a/fcd/callconv/cc_common.h
+++ b/fcd/callconv/cc_common.h
@@ -10,8 +10,8 @@
 #ifndef fcd__callconv_cc_common_h
 #define fcd__callconv_cc_common_h
 
-#include "targetinfo.h"
 #include "params_registry.h"
+#include "targetinfo.h"
 
 #include <llvm/IR/Function.h>
 

--- a/fcd/callconv/params_registry.cpp
+++ b/fcd/callconv/params_registry.cpp
@@ -128,10 +128,10 @@ namespace
 		bool old;
 		bool& value;
 		
-		TemporaryTrue(bool& value)
-		: value(value)
+		TemporaryTrue(bool& val)
+		: value(val)
 		{
-			old = value;
+			old = val;
 			value = true;
 		}
 		
@@ -194,7 +194,8 @@ CallInformation* ParameterRegistry::analyzeFunction(Function& fn)
 	{
 		for (CallingConvention* cc : ccChain)
 		{
-			PrettyStackTraceFormat analyzing("Analyzing function \"%s\" with calling convention \"%s\"", string(fn.getName()).c_str(), cc->getName());
+			PrettyStackTraceFormat analyzingFunction("Analyzing function \"%s\" with calling convention \"%s\"",
+				string(fn.getName()).c_str(), cc->getName());
 			
 			info.setStage(CallInformation::Analyzing);
 			if (cc->analyzeFunction(*this, info, fn))
@@ -280,7 +281,8 @@ const CallInformation* ParameterRegistry::getDefinitionCallInfo(Function& functi
 			raw_string_ostream functionTypeStream(functionType);
 			function.getFunctionType()->print(functionTypeStream);
 			functionTypeStream.flush();
-			PrettyStackTraceFormat analyzing("Analyzing function type \"%s\" with calling convention \"%s\"", functionType.c_str(), cc->getName());
+			PrettyStackTraceFormat analyzingFunction("Analyzing function type \"%s\" with calling convention \"%s\"",
+				functionType.c_str(), cc->getName());
 			
 			if (cc->analyzeFunctionType(*this, info, *function.getFunctionType()))
 			{
@@ -312,7 +314,8 @@ unique_ptr<CallInformation> ParameterRegistry::analyzeCallSite(CallSite callSite
 			calleeName = "(not a function)";
 		}
 		string callerName = callSite->getFunction()->getName();
-		PrettyStackTraceFormat analyzing("Analyzing call site for \"%s\" in \"%s\" with calling convention \"%s\"", calleeName.c_str(), callerName.c_str(), cc->getName());
+		PrettyStackTraceFormat analyzingFunction("Analyzing call site for \"%s\" in \"%s\" with calling convention \"%s\"",
+			calleeName.c_str(), callerName.c_str(), cc->getName());
 		
 		info->setStage(CallInformation::Analyzing);
 		if (cc->analyzeCallSite(*this, *info, callSite))

--- a/fcd/callconv/x86_64_systemv.cpp
+++ b/fcd/callconv/x86_64_systemv.cpp
@@ -287,9 +287,9 @@ bool CallingConvention_x86_64_systemv::analyzeFunction(ParameterRegistry &regist
 	
 	// Look at temporary registers that are read before they are written
 	MemorySSA& mssa = *registry.getMemorySSA(function);
-	for (const char* name : parameterRegisters)
+	for (const char* regName : parameterRegisters)
 	{
-		const TargetRegisterInfo* smallReg = targetInfo.registerNamed(name);
+		const TargetRegisterInfo* smallReg = targetInfo.registerNamed(regName);
 		const TargetRegisterInfo& regInfo = targetInfo.largestOverlappingRegister(*smallReg);
 		auto range = geps.equal_range(&regInfo);
 		
@@ -336,10 +336,10 @@ bool CallingConvention_x86_64_systemv::analyzeFunction(ParameterRegistry &regist
 			if (auto load = dyn_cast<LoadInst>(use.getUser()))
 			{
 				// Find uses above +8 (since +0 is the return address)
-				for (auto& use : load->uses())
+				for (auto& loadUse : load->uses())
 				{
 					ConstantInt* offset = nullptr;
-					if (match(use.get(), m_Add(m_Value(), m_ConstantInt(offset))))
+					if (match(loadUse.get(), m_Add(m_Value(), m_ConstantInt(offset))))
 					{
 						auto intOffset = static_cast<int64_t>(offset->getLimitedValue());
 						if (intOffset > 8)
@@ -357,9 +357,9 @@ bool CallingConvention_x86_64_systemv::analyzeFunction(ParameterRegistry &regist
 	vector<const TargetRegisterInfo*> usedReturns;
 	usedReturns.reserve(2);
 	
-	for (const char* name : returnRegisters)
+	for (const char* regName : returnRegisters)
 	{
-		const TargetRegisterInfo* regInfo = targetInfo.registerNamed(name);
+		const TargetRegisterInfo* regInfo = targetInfo.registerNamed(regName);
 		auto range = geps.equal_range(regInfo);
 		for (auto iter = range.first; iter != range.second; ++iter)
 		{

--- a/fcd/capstone_wrapper.cpp
+++ b/fcd/capstone_wrapper.cpp
@@ -7,9 +7,10 @@
 // license. See LICENSE.md for details.
 //
 
+#include "capstone_wrapper.h"
+
 #include <string>
 #include <system_error>
-#include "capstone_wrapper.h"
 
 using namespace llvm;
 using namespace std;

--- a/fcd/capstone_wrapper.h
+++ b/fcd/capstone_wrapper.h
@@ -10,7 +10,6 @@
 #ifndef fcd__capstone_wrapper_h
 #define fcd__capstone_wrapper_h
 
-
 #include <llvm/Support/ErrorOr.h>
 
 #include <capstone/capstone.h>

--- a/fcd/codegen/code_generator.cpp
+++ b/fcd/codegen/code_generator.cpp
@@ -245,7 +245,7 @@ namespace
 					ConstantInt::get(int32Ty, cs.operands[i].mem.base),
 					ConstantInt::get(int32Ty, cs.operands[i].mem.index),
 					ConstantInt::get(int32Ty, static_cast<unsigned>(cs.operands[i].mem.scale)),
-					ConstantInt::get(int64Ty, cs.operands[i].mem.disp),
+					ConstantInt::get(int64Ty, static_cast<uint64_t>(cs.operands[i].mem.disp)),
 				};
 				Constant* opMem = ConstantStruct::get(x86OpMem, structFields);
 				Constant* wrapper = ConstantStruct::get(x86OpMemWrapper, opMem, nullptr);
@@ -267,9 +267,9 @@ namespace
 				ConstantInt::get(int8Ty, cs.addr_size),
 				ConstantInt::get(int8Ty, cs.modrm),
 				ConstantInt::get(int8Ty, cs.sib),
-				ConstantInt::get(int32Ty, cs.disp),
+				ConstantInt::get(int32Ty, static_cast<uint32_t>(cs.disp)),
 				ConstantInt::get(int32Ty, cs.sib_index),
-				ConstantInt::get(int8Ty, cs.sib_scale),
+				ConstantInt::get(int8Ty, static_cast<uint8_t>(cs.sib_scale)),
 				ConstantInt::get(int32Ty, cs.sib_base),
 				ConstantInt::get(int32Ty, cs.sse_cc),
 				ConstantInt::get(int32Ty, cs.avx_cc),

--- a/fcd/codegen/translation_maps.h
+++ b/fcd/codegen/translation_maps.h
@@ -10,7 +10,6 @@
 #ifndef translation_maps_h
 #define translation_maps_h
 
-
 #include <llvm/IR/BasicBlock.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Module.h>

--- a/fcd/command_line.h
+++ b/fcd/command_line.h
@@ -10,7 +10,6 @@
 #ifndef fcd__command_line_h
 #define fcd__command_line_h
 
-
 #include <llvm/Support/CommandLine.h>
 
 struct whitelist

--- a/fcd/cpu/x86_register_map.cpp
+++ b/fcd/cpu/x86_register_map.cpp
@@ -38,11 +38,11 @@ namespace
 			}
 		}
 		
-		inline void regInfo(size_t size, size_t offset, const string& name, x86_reg registerId)
+		inline void regInfo(size_t size, size_t off, const string& name, x86_reg registerId)
 		{
 			if (registerId != X86_REG_INVALID)
 			{
-				TargetRegisterInfo result = { offset, offset - this->offset, size, {fieldOffset, 0}, name, registerId };
+				TargetRegisterInfo result = { off, off - this->offset, size, {fieldOffset, 0}, name, registerId };
 				info.push_back(result);
 			}
 		}

--- a/fcd/dumb_allocator.h
+++ b/fcd/dumb_allocator.h
@@ -10,16 +10,15 @@
 #ifndef fcd__dumb_allocator_h
 #define fcd__dumb_allocator_h
 
-
 #include <llvm/ADT/StringRef.h>
 
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <cstring>
 #include <iterator>
 #include <list>
 #include <memory>
-#include <cstring>
 #include <type_traits>
 
 #include <iostream>

--- a/fcd/main.cpp
+++ b/fcd/main.cpp
@@ -15,8 +15,8 @@
 #include "main.h"
 #include "metadata.h"
 #include "passes.h"
-#include "python_context.h"
 #include "params_registry.h"
+#include "python_context.h"
 #include "translation_context.h"
 
 #include <llvm/Analysis/AliasAnalysis.h>

--- a/fcd/metadata.cpp
+++ b/fcd/metadata.cpp
@@ -147,9 +147,9 @@ bool md::isPrototype(const Function &fn)
 		const BasicBlock& entry = fn.getEntryBlock();
 		if (entry.getInstList().size() == 2)
 		if (const CallInst* call = dyn_cast<CallInst>(entry.begin()))
-		if (Function* fn = call->getCalledFunction())
+		if (Function* func = call->getCalledFunction())
 		{
-			return fn->getName().startswith("fcd.placeholder");
+			return func->getName().startswith("fcd.placeholder");
 		}
 	}
 	

--- a/fcd/metadata.h
+++ b/fcd/metadata.h
@@ -13,8 +13,8 @@
 #include "params_registry.h"
 
 #include <llvm/IR/Constants.h>
-#include <llvm/IR/Instructions.h>
 #include <llvm/IR/Function.h>
+#include <llvm/IR/Instructions.h>
 #include <llvm/IR/Metadata.h>
 
 #include <string>

--- a/fcd/not_null.h
+++ b/fcd/not_null.h
@@ -10,7 +10,6 @@
 #ifndef fcd__not_null_h
 #define fcd__not_null_h
 
-
 #include <llvm/Support/Casting.h>
 
 #ifdef FCD_DEBUG

--- a/fcd/pass_locals.cpp
+++ b/fcd/pass_locals.cpp
@@ -257,14 +257,14 @@ namespace
 			{
 			}
 			
-			uint64_t size(const DataLayout& dl) const
+			uint64_t size(const DataLayout& layout) const
 			{
-				return type->isVoidTy() ? 0 : dl.getTypeStoreSize(type);
+				return type->isVoidTy() ? 0 : layout.getTypeStoreSize(type);
 			}
 			
-			int64_t endOffset(const DataLayout& dl) const
+			int64_t endOffset(const DataLayout& layout) const
 			{
-				return offset + static_cast<int64_t>(size(dl));
+				return offset + static_cast<int64_t>(size(layout));
 			}
 		};
 		
@@ -476,16 +476,16 @@ namespace
 		{
 		}
 		
-		void setIndex(NOT_NULL(Value) index, NOT_NULL(Type) expectedType)
+		void setIndex(NOT_NULL(Value) idx, NOT_NULL(Type) expected)
 		{
-			this->index = index;
-			this->expectedType = expectedType;
+			this->index = idx;
+			this->expectedType = expected;
 		}
 		
-		void setParent(GepLink* parent)
+		void setParent(GepLink* p)
 		{
 			assert(this->parent == nullptr);
-			this->parent = parent;
+			this->parent = p;
 		}
 		
 		GepLink* getParent() { return parent; }
@@ -1019,16 +1019,16 @@ namespace
 					
 					// change argument references
 					SmallVector<Argument*, 8> oldArgs;
-					for (Argument& arg : fn.args())
+					for (Argument& argument : fn.args())
 					{
-						oldArgs.push_back(&arg);
+						oldArgs.push_back(&argument);
 					}
 					oldArgs.erase(oldArgs.begin() + index);
 					
 					SmallVector<Argument*, 8> newArgs;
-					for (Argument& arg : newFunc->args())
+					for (Argument& argument : newFunc->args())
 					{
-						newArgs.push_back(&arg);
+						newArgs.push_back(&argument);
 					}
 					
 					for (size_t i = 0; i < newArgs.size(); ++i)

--- a/fcd/pass_locals.cpp
+++ b/fcd/pass_locals.cpp
@@ -594,7 +594,7 @@ namespace
 						return nullptr;
 					}
 					auto fieldLink = linkFor(access.object);
-					fieldLink->setIndex(ConstantInt::get(i32, iter->second), access.type);
+					fieldLink->setIndex(ConstantInt::get(i32, static_cast<uint64_t>(iter->second)), access.type);
 					fieldLink->setParent(structureLink);
 				}
 			}

--- a/fcd/pass_regaa.cpp
+++ b/fcd/pass_regaa.cpp
@@ -12,8 +12,8 @@
 // http://lists.cs.uiuc.edu/pipermail/llvm-commits/Week-of-Mon-20111010/129632.html
 
 #include "metadata.h"
-#include "passes.h"
 #include "pass_regaa.h"
+#include "passes.h"
 
 #include <llvm/Analysis/AliasAnalysis.h>
 #include <llvm/Analysis/Passes.h>

--- a/fcd/pass_regaa.h
+++ b/fcd/pass_regaa.h
@@ -10,7 +10,6 @@
 #ifndef pass_regaa_h
 #define pass_regaa_h
 
-
 #include <llvm/Analysis/AliasAnalysis.h>
 #include <llvm/Pass.h>
 

--- a/fcd/passes.h
+++ b/fcd/passes.h
@@ -10,16 +10,16 @@
 #ifndef fcd__passes_h
 #define fcd__passes_h
 
-#include <llvm/Pass.h>
-#include <llvm/Analysis/AliasAnalysis.h>
-#include <llvm/Analysis/Passes.h>
-#include <llvm/Transforms/Utils/MemorySSA.h>
-
 #include "pass_argrec.h"
 #include "pass_backend.h"
 #include "pass_executable.h"
 #include "pass_regaa.h"
 #include "targetinfo.h"
+
+#include <llvm/Analysis/AliasAnalysis.h>
+#include <llvm/Analysis/Passes.h>
+#include <llvm/Pass.h>
+#include <llvm/Transforms/Utils/MemorySSA.h>
 
 llvm::FunctionPass*		createRegisterPointerPromotionPass();
 

--- a/fcd/targetinfo.h
+++ b/fcd/targetinfo.h
@@ -10,7 +10,6 @@
 #ifndef fcd__targetinfo_h
 #define fcd__targetinfo_h
 
-
 #include <llvm/IR/DataLayout.h>
 #include <llvm/IR/Instructions.h>
 


### PR DESCRIPTION
Alphabetizes the include statements and fixes most build warnings. The shadow warnings can also be fixed by removing the `-Wshadow` in CMakeLists.txt