### PR TITLE
FCD-1 - In "Build Rules", replaced `TOOLCHAIN_DIR` with `LLVM_BUILD_D…

### DIFF
--- a/fcd.xcodeproj/project.pbxproj
+++ b/fcd.xcodeproj/project.pbxproj
@@ -127,7 +127,7 @@
 			outputFiles = (
 				"$(DERIVED_FILE_DIR)/$(INPUT_FILE_NAME).bc.s",
 			);
-			script = "$LLVM_BIN_DIR/bin/clang++ -c -emit-llvm --std=gnu++14 --stdlib=libc++ -isysroot $SDKROOT -I$TOOLCHAIN_DIR/usr/include/c++/v1 -I$CAPSTONE_DIR/include -O3 -o $DERIVED_FILE_DIR/$INPUT_FILE_NAME.bc $INPUT_FILE_PATH || exit 1\n\nexport CPU=`basename $INPUT_FILE_NAME .emulator.cpp`\nsed -e \"s/{CPU}/$CPU/\" $INPUT_FILE_DIR/incbin.Darwin.tpl > $DERIVED_FILE_DIR/$INPUT_FILE_NAME.bc.s\n";
+			script = "$LLVM_BIN_DIR/bin/clang++ -c -emit-llvm --std=gnu++14 --stdlib=libc++ -isysroot $SDKROOT -I$LLVM_BUILD_DIR/usr/include/c++/v1 -I$CAPSTONE_DIR/include -O3 -o $DERIVED_FILE_DIR/$INPUT_FILE_NAME.bc $INPUT_FILE_PATH || exit 1\n\nexport CPU=`basename $INPUT_FILE_NAME .emulator.cpp`\nsed -e \"s/{CPU}/$CPU/\" $INPUT_FILE_DIR/incbin.Darwin.tpl > $DERIVED_FILE_DIR/$INPUT_FILE_NAME.bc.s\n";
 		};
 /* End PBXBuildRule section */
 


### PR DESCRIPTION
…IR` as I believe the build was attempting to use the "latest" clang's includes on the system, whereas we'd require the includes that came with llvm-4.0.0